### PR TITLE
Attempt to fix AppStore upload error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-purchase-braintree",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-purchase-braintree",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "description": "A Cordova plugin for the Braintree mobile payment processing SDK with 3D secure and Data Collecting.",
   "cordova": {
     "id": "cordova-plugin-purchase-braintree",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-purchase-braintree"
-        version="13.1.3">
+        version="13.1.5">
 
     <name>Braintree Adapter for cordova-plugin-purchase</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -243,6 +243,7 @@
         <framework src="lib/ios/BraintreeUnionPay.xcframework/ios-arm64/BraintreeUnionPay.framework" />
         <framework src="lib/ios/BraintreeVenmo.xcframework" custom="true" embed="true" weak="false" />
         <framework src="lib/ios/PayPalDataCollector.xcframework" custom="true" embed="true" weak="false" />
+        <framework src="lib/ios/PayPalCheckout.xcframework" custom="true" embed="true" weak="false" />
 
         <!-- framework src="lib/ios/BraintreeDropIn.xcframework" custom="true" embed="true" weak="false" / -->
         <!-- framework src="lib/ios/BraintreeUI.xcframework" custom="true" embed="true" weak="false" / -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -236,7 +236,7 @@
         <framework src="lib/ios/BraintreeDataCollector.xcframework" custom="true" embed="true" weak="false" />
         <framework src="lib/ios/BraintreePaymentFlow.xcframework" custom="true" embed="true" weak="false" />
         <framework src="lib/ios/BraintreePayPal.xcframework" custom="true" embed="true" weak="false" />
-        <framework src="lib/ios/BraintreePayPalNativeCheckout.xcframework" custom="true" embed="true" weak="false" />
+        <framework src="lib/ios/BraintreePayPalNativeCheckout.xcframework" custom="true" embed="true" weak="true" />
         <framework src="lib/ios/BraintreeSEPADirectDebit.xcframework" custom="true" embed="true" weak="false" />
         <framework src="lib/ios/BraintreeThreeDSecure.xcframework" custom="true" embed="true" weak="false" />
         <framework src="lib/ios/BraintreeUnionPay.xcframework" custom="true" embed="true" weak="false" />

--- a/www/braintree-plugin.js
+++ b/www/braintree-plugin.js
@@ -1,4 +1,4 @@
 module.exports = {
-  version: "13.1.3",
+  version: "13.1.5",
   installed: true,
 }


### PR DESCRIPTION
When uploading, we get this error:

Invalid Bundle. The bundle at
'XXX.app/Frameworks/BraintreePayPaiNativeCheckout.framework' contains disallowed nested bundles.

Trying to disable framework embedding hoping it'll fix the issue. I also had to set "weak=true" or I had a runtime error.

Tested a sandbox paypal payment, which worked.